### PR TITLE
Do not use local repo (#19)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.3.3</version>


### PR DESCRIPTION
Prevents items from not having any URL entry when present in the current user's local Maven cache.

Adds dependency on commons-io for FileUtils.getTempDirectory()