### PR TITLE
Replaced `<tt>` with `<code>` as `<tt>` is not supported by html5

### DIFF
--- a/src/main/java/org/nixos/mvn2nix/ParentPOMPropagatingArtifactDescriptorReaderDelegate.java
+++ b/src/main/java/org/nixos/mvn2nix/ParentPOMPropagatingArtifactDescriptorReaderDelegate.java
@@ -33,7 +33,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.graph.Dependency;
 
 /**
- * An <tt>ArtifactDescriptorReaderDelegate</tt> that adds any
+ * An <code>ArtifactDescriptorReaderDelegate</code> that adds any
  * &lt;parent&gt; POMs as dependencies.
  *
  * @author Shea Levy


### PR DESCRIPTION
html4 option was removed on java 13 and html5 was made default.

This caused build to fail with maven version in `nixos-unstable`.

/cc @jerith666 @shlevy

